### PR TITLE
Ready for 070

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -142,8 +142,8 @@ WORKDIR /root/
 CMD idris2 -p idris2 -p contrib -p network -p test
 
 # ----------------------------------------------------
-FROM idris-060 as idris-070
-#FROM mattpolzin2/idris-docker:0.6.0 as idris-070
+# FROM idris-060 as idris-070
+FROM mattpolzin2/idris-docker:0.6.0 as idris-070
 
 WORKDIR /build/
 
@@ -169,8 +169,8 @@ WORKDIR /root/
 CMD idris2 -p idris2 -p contrib -p network -p test
 
 # ----------------------------------------------------
-FROM idris-070 as idris-nightly
-#FROM mattpolzin2/idris-docker:0.6.0 as idris-nightly
+# FROM idris-070 as idris-nightly
+FROM mattpolzin2/idris-docker:0.6.0 as idris-nightly
 
 WORKDIR /build/
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -142,8 +142,35 @@ WORKDIR /root/
 CMD idris2 -p idris2 -p contrib -p network -p test
 
 # ----------------------------------------------------
-# FROM idris-060 as idris-nightly
-FROM mattpolzin2/idris-docker:0.6.0 as idris-nightly
+FROM idris-060 as idris-070
+#FROM mattpolzin2/idris-docker:0.6.0 as idris-070
+
+WORKDIR /build/
+
+RUN curl -L -o 070.tar.gz https://github.com/idris-lang/Idris2/archive/refs/tags/v0.7.0.tar.gz && \
+ tar -xzf 070.tar.gz && \
+ cd Idris2-0.7.0 && \
+ make && \
+ rm -rf ~/.idris2 && \
+ make install
+
+WORKDIR /build/Idris2-0.7.0/
+
+RUN make clean && \
+ make && \
+ make install && \
+ make install-api
+
+RUN cd ../.. && \
+ rm -rf ./build
+
+WORKDIR /root/
+
+CMD idris2 -p idris2 -p contrib -p network -p test
+
+# ----------------------------------------------------
+FROM idris-070 as idris-nightly
+#FROM mattpolzin2/idris-docker:0.6.0 as idris-nightly
 
 WORKDIR /build/
 
@@ -201,7 +228,8 @@ RUN idv install 0.2.2 && \
     idv install 0.3.0 --api && \
     idv install 0.4.0 --api --lsp && \
     idv install 0.5.1 --api --lsp && \
-    idv install 0.6.0 --api --lsp
+    idv install 0.6.0 --api --lsp && \
+    idv install 0.7.0 --api --lsp
 
 CMD bash -c 'echo "Idris 2 Versions:" && idv list && echo "------" && idris2 -p idris2 -p contrib -p network -p test'
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## Usage
 
 ### Running Locally
-To run one of the Ubuntu Idris docker images, pick a supported version tag (**0.2.2**, **0.3.0**, **0.4.0**, **0.5.1**, or **nightly**) to specify after the colon and run the following command from an environment with a Docker daemon installed and running:
+To run one of the Ubuntu Idris docker images, pick a supported version tag (**0.2.2**, **0.3.0**, **0.4.0**, **0.5.1**, **0.6.0**, **0.7.0**, or **nightly**) to specify after the colon and run the following command from an environment with a Docker daemon installed and running:
 
 ```shell
 docker run -ti mattpolzin2/idris-docker:latest
@@ -72,24 +72,26 @@ In addition to different Docker images for each version of Idris 2, there is an 
 docker run -ti mattpolzin2/idris-docker:idv bash
 $ idv list
 * system (installed)
+  0.7.0  (installed)
+  0.6.0  (installed)
   0.5.1  (installed)
-  0.4.0  (installed)
-  0.3.0  (installed)
-  0.2.2  (installed)
+  0.4.0
+  0.3.0
+  0.2.2
   0.2.1
   0.2.0
 $ idv select 0.3.0
 
-Idris 2 version 0.3.0 selected.
+Idris 2 version 0.6.0 selected.
 
 $ idris2 --version
-Idris 2, version 0.3.0
+Idris 2, version 0.6.0
 $ idv select system
 
 System copy of Idris 2 selected.
 
 $ idris2 --version
-Idris 2, version 0.4.0-nightly
+Idris 2, version 0.7.0-nightly
 ```
 
 Notice that the `system` version of Idris 2 is the version you will find in the `nightly` Docker image (i.e. it is _newer_ than the lastest stable version, which is also installed and selectable via Idv).
@@ -120,7 +122,7 @@ jobs:
 ```
 
 ## Building Idris Docker Images
-From the root directory of this repository, pick a stage to build (**idris-022**, **idris-030**, **idris-040**, **idris-051**, **idris-nightly**, or **idv**), and then:
+From the root directory of this repository, pick a stage to build (**idris-022**, **idris-030**, **idris-040**, **idris-051**, **idris-060**, **idris-070**, **idris-nightly**, or **idv**), and then:
 
 ```shell
 docker build -t local/idris-docker:nightly --target idris-nightly -f Dockerfile.ubuntu .


### PR DESCRIPTION
- [x] Need to cut new LSP repository branch (`idris2-0.7.0`) so that `idv` will be able to find the LSP for v0.7.0 before merging since nightly jobs build an `idv` image.