### PR TITLE
Move to nodejs20

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -170,7 +170,7 @@ CMD idris2 -p idris2 -p contrib -p network -p test
 
 # ----------------------------------------------------
 # FROM idris-070 as idris-nightly
-FROM mattpolzin2/idris-docker:0.6.0 as idris-nightly
+FROM mattpolzin2/idris-docker:0.7.0 as idris-nightly
 
 WORKDIR /build/
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
  apt-get install -y curl chezscheme racket gcc make vim rlwrap libgmp3-dev ca-certificates
 
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 
 RUN apt-get install -y nodejs
 
@@ -224,11 +224,7 @@ RUN ln -s /root/.idv/bin/idv /usr/local/bin/idv && \
  rm /usr/local/bin/idris2 && \
  ln -s /root/.idv/bin/idris2 /usr/local/bin/idris2
 
-RUN idv install 0.2.2 && \
-    idv install 0.3.0 --api && \
-    idv install 0.4.0 --api --lsp && \
-    idv install 0.5.1 --api --lsp && \
-    idv install 0.6.0 --api --lsp && \
+RUN idv install 0.6.0 --api --lsp && \
     idv install 0.7.0 --api --lsp
 
 CMD bash -c 'echo "Idris 2 Versions:" && idv list && echo "------" && idris2 -p idris2 -p contrib -p network -p test'


### PR DESCRIPTION
Also, fix nightly docker stage and drop initial idv image installs of several of the older versions of Idris2.